### PR TITLE
Add X11 (a.k.a., MIT) License.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,26 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: eos-metrics
 Upstream-Contact: Kurt von Laven <kurt@endlessm.com>
-Disclaimer: This package is not part of Debian. It is proprietary software.
-Copyright: Copyright 2014 Endless Mobile, Inc.
-License: Proprietary
+Copyright: Copyright 2013-2014 Endless Mobile, Inc.
+License: X11
+ The MIT License (MIT)
+
+ Copyright (c) 2013-2014 Endless Mobile, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.


### PR DESCRIPTION
We are open-sourcing this repository since we use it from our fork of
mutter, which is released under GNU GPLv2. The X11 License is compatible
with GNU GPLv2 but much more permissive. The X11 License allows us to
use this repository from both our closed-source and open-source code in
addition to allowing anyone else to do the same.

[endlessm/eos-sdk#2043]
