### PR TITLE
Change suggests to recommends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Section: non-free/libs
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends}
-Suggests: eos-event-recorder-daemon
+Recommends: eos-event-recorder-daemon
 Description: EndlessOS Metrics Kit
  Library for recording and sending metrics data in EndlessOS.
 


### PR DESCRIPTION
Recommend eos-event-recorder-daemon so that apt-get automatically tries
to install eos-event-recorder-daemon when someone installs eos-metrics
on the command line. If eos-event-recorder-daemon isn't available,
apt-get will happily carry on without it.

[endlessm/eos-sdk#2043]
