### PR TITLE
Move _POSIX_C_SOURCE check after sys/types.h

### DIFF
--- a/eosmetrics/emtr-util.h
+++ b/eosmetrics/emtr-util.h
@@ -27,12 +27,12 @@
 #ifndef EMTR_UTIL_PRIVATE_H
 #define EMTR_UTIL_PRIVATE_H
 
+#include <sys/types.h>
+
 /* For clockid_t */
 #if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 199309L
 #error "This code requires _POSIX_C_SOURCE to be 199309L or later."
 #endif
-
-#include <sys/types.h>
 
 #include <glib.h>
 


### PR DESCRIPTION
If the user hasn't explicitly declared _POSIX_C_SOURCE to the compiler,
then we want to make sure the that system's default feature test macros
are included before checking against them. We could explicitly include
`<features.h>`, but since this is glibc specific, just delay the check
until after including `<sys/types.h>`, which will pull in `<features.h>` as
part of glibc's implementation. See feature_test_macros(7) for details.

[endlessm/eos-sdk#2449]
