### PR TITLE
Strict flags and GIR docs enabled by default.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,11 +42,7 @@ AM_CFLAGS = @STRICT_CFLAGS@
 
 # Make sure to run Gtk-doc tests and build the documentation when doing
 # 'make distcheck'
-AM_DISTCHECK_CONFIGURE_FLAGS = \
-	--enable-gtk-doc \
-	--enable-gir-doc \
-	--enable-strict-flags \
-	$(NULL)
+AM_DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc
 
 # Generated files that 'make clean' should erase
 CLEANFILES =
@@ -61,8 +57,8 @@ dist-hook:
 else
 dist-hook:
 	@echo "***"
-	@echo "*** You must configure with --enable-gtk-doc and --enable-gir-doc to"
-	@echo "*** run make dist or make distcheck."
+	@echo "*** You must configure with --enable-gtk-doc to run make dist or"
+	@echo "*** make distcheck."
 	@echo "***"
 	@false
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -146,9 +146,9 @@ AC_CACHE_SAVE
 # during 'make distcheck'.
 AC_ARG_ENABLE([strict-flags],
     [AS_HELP_STRING([--enable-strict-flags=@<:@no/yes/error@:>@],
-        [Use strict compiler flags @<:@default=no@:>@])],
+        [Use strict compiler flags @<:@default=yes@:>@])],
     [],
-    [enable_strict_flags=no])
+    [enable_strict_flags=yes])
 # Emmanuele's list of flags
 STRICT_COMPILER_FLAGS="$STRICT_COMPILER_FLAGS
     -Wall
@@ -182,7 +182,9 @@ AC_SUBST(STRICT_CFLAGS)
 # during 'make distcheck'.
 AC_ARG_ENABLE([gir-doc],
     [AS_HELP_STRING([--enable-gir-doc],
-        [Build GIR documentation for JavaScript @<:@default=no@:>@])])
+        [Build GIR documentation for JavaScript @<:@default=yes@:>@])],
+    [],
+    [enable_gir_doc=yes])
 AS_IF([test "x$enable_gir_doc" = "xyes"], [
     AS_IF([test "x$GIRDOCTOOL" = "xnotfound"],
         [AC_MSG_ERROR([g-ir-doc-tool must be installed for --enable-gir-doc])])

--- a/configure.ac
+++ b/configure.ac
@@ -178,11 +178,11 @@ dnl Strip leading spaces
 STRICT_CFLAGS=${STRICT_CFLAGS#*  }
 AC_SUBST(STRICT_CFLAGS)
 
-# --enable-gir-doc: Build GIR documentation for Javascript. Done automatically
+# --enable-gir-doc: Build GIR documentation for JavaScript. Done automatically
 # during 'make distcheck'.
 AC_ARG_ENABLE([gir-doc],
     [AS_HELP_STRING([--enable-gir-doc],
-        [Build GIR documentation for Javascript @<:@default=no@:>@])])
+        [Build GIR documentation for JavaScript @<:@default=no@:>@])])
 AS_IF([test "x$enable_gir_doc" = "xyes"], [
     AS_IF([test "x$GIRDOCTOOL" = "xnotfound"],
         [AC_MSG_ERROR([g-ir-doc-tool must be installed for --enable-gir-doc])])


### PR DESCRIPTION
The configure.ac file now instructs Autoconf to set the default values to true
for the flags --enable-strict-flags and --enable-gir-doc.

[endlessm/eos-sdk#1978]