### PR TITLE
Minor cleanup

### DIFF
--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -268,12 +268,6 @@ get_time_with_maybe_variant (EmtrEventRecorder *self,
   return g_variant_new ("(xbv)", relative_time, has_payload, maybe_payload);
 }
 
-/* 
- * Determines if a maybe variant exists anywhere within the given GVariant. 
- * If this GVariant does contain a maybe type, it will log a critical
- * warning and return TRUE. If no maybe types are found, it will return
- * FALSE. 
- */
 static gboolean
 check_for_maybe_variant (GVariant *variant)
 {

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -33,6 +33,7 @@
 #include "emer-event-recorder-server.h"
 #include "eosmetrics/emtr-util.h"
 
+#include <string.h>
 #include <time.h>
 
 #include <gio/gio.h>
@@ -276,7 +277,7 @@ contains_maybe_variant (GVariant *variant)
 
   // type_string belongs to the GVariant and should not be freed.
   const gchar *type_string = g_variant_get_type_string (variant);
-  gchar *found_character = g_strrstr (type_string, "m");
+  gchar *found_character = strstr (type_string, "m");
   if (found_character != NULL)
     {
       g_critical ("Maybe type found in auxiliary payload. These are not "

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -269,7 +269,7 @@ get_time_with_maybe_variant (EmtrEventRecorder *self,
 }
 
 static gboolean
-check_for_maybe_variant (GVariant *variant)
+contains_maybe_variant (GVariant *variant)
 {
   if (variant == NULL)
     return FALSE;
@@ -502,7 +502,7 @@ emtr_event_recorder_record_event (EmtrEventRecorder *self,
   g_return_if_fail (event_id != NULL);
   g_return_if_fail (auxiliary_payload == NULL || _IS_VARIANT(auxiliary_payload));
 
-  if (check_for_maybe_variant (auxiliary_payload))
+  if (contains_maybe_variant (auxiliary_payload))
     return;
 
 #ifdef DEBUG
@@ -591,7 +591,7 @@ emtr_event_recorder_record_events (EmtrEventRecorder *self,
   g_return_if_fail (event_id != NULL);
   g_return_if_fail (auxiliary_payload == NULL || _IS_VARIANT(auxiliary_payload));
 
-  if (check_for_maybe_variant (auxiliary_payload))
+  if (contains_maybe_variant (auxiliary_payload))
     return;
 
 #ifdef DEBUG
@@ -686,7 +686,7 @@ emtr_event_recorder_record_start (EmtrEventRecorder *self,
   g_return_if_fail (auxiliary_payload == NULL ||
                     _IS_VARIANT (auxiliary_payload));
 
-  if (check_for_maybe_variant (auxiliary_payload))
+  if (contains_maybe_variant (auxiliary_payload))
     return;
 
 #ifdef DEBUG
@@ -804,7 +804,7 @@ emtr_event_recorder_record_progress (EmtrEventRecorder *self,
   g_return_if_fail (auxiliary_payload == NULL ||
                     _IS_VARIANT (auxiliary_payload));
 
-  if (check_for_maybe_variant (auxiliary_payload))
+  if (contains_maybe_variant (auxiliary_payload))
     return;
 
 #ifdef DEBUG
@@ -922,7 +922,7 @@ emtr_event_recorder_record_stop (EmtrEventRecorder *self,
   g_return_if_fail (auxiliary_payload == NULL ||
                     _IS_VARIANT (auxiliary_payload));
 
-  if (check_for_maybe_variant (auxiliary_payload))
+  if (contains_maybe_variant (auxiliary_payload))
     return;
 
 #ifdef DEBUG


### PR DESCRIPTION
Removed a comment.

The comment was redundant with the code, so we'd prefer not to maintain
it.

Rename check_for_maybe_variant function.

The name contains_maybe_variant more clearly indicates that the method
returns a boolean and has no side effects.

Replace g_strrstr with strstr.

The use of g_strrstr, which searches the haystack from back to front,
implies that the order of traversal matters. This is not the case, so
we use strstr instead.

[endlessm/eos-sdk#2803]