### PR TITLE
Update copyright file to LGPLv2.1+

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,26 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: eos-metrics
 Upstream-Contact: Kurt von Laven <kurt@endlessm.com>
-Copyright: Copyright 2013-2014 Endless Mobile, Inc.
-License: X11
- The MIT License (MIT)
-
- Copyright (c) 2013-2014 Endless Mobile, Inc.
-
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
-
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
+Copyright: Copyright 2013, 2014, 2015 Endless Mobile, Inc. All rights reserved.
+License: LGPL-2.1+


### PR DESCRIPTION
This updates the copyright year and specifies that the package is
licensed under LGPLv2.1 or later.

[endlessm/eos-sdk#2900]