### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,8 +35,8 @@ m4_define([_EMTR_API_VERSION_MACRO], [0])
 # version is even for a stable release and odd for a development release.
 # When making any release, if the API changes, set the interface age to 0.
 m4_define([_EMTR_MINOR_VERSION_MACRO], [2])
-m4_define([_EMTR_MICRO_VERSION_MACRO], [0])
-m4_define([_EMTR_INTERFACE_AGE_MACRO], [0])
+m4_define([_EMTR_MICRO_VERSION_MACRO], [1])
+m4_define([_EMTR_INTERFACE_AGE_MACRO], [1])
 
 # Full version, for use in AC_INIT
 m4_define([_EMTR_VERSION_MACRO],


### PR DESCRIPTION
The version of eos-metrics going out with OS release 2.3.0 is 0.2.1,
since we have not changed any API since 2.2.0. Increment the interface
age accordingly.

[endlessm/eos-sdk#2736]