### PR TITLE
Bump API version from 0.2.0 to 0.3.0.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+eos-metrics (0.3.0) unstable; urgency=low
+
+  * Add synchronous versions of event recorder methods that call D-Bus.
+  * Deprecate emtr_event_id_to_name method and event IDs.
+
+ -- Kurt von Laven <kurt@endlessm.com>  Wed, 08 Apr 2015 12:29:00 -0500
+
 eos-metrics (0.2.0) unstable; urgency=low
 
   * Package now installs utility header and event recorder server XML files.


### PR DESCRIPTION
Bumped the minor version from 2 to 3 because some new methods were
added to the event recorder API, and a method and some constants were
deprecated.

[endlessm/eos-sdk#3029]