### PR TITLE
Prefer G_GINT64_FORMAT to PRId64.

### DIFF
--- a/eosmetrics/emtr-util.c
+++ b/eosmetrics/emtr-util.c
@@ -28,7 +28,6 @@
 
 #include <errno.h>
 #include <time.h>
-#include <inttypes.h>
 
 #include <glib.h>
 
@@ -89,7 +88,7 @@ emtr_util_get_current_time (clockid_t clock_id,
       /* The (gint64) conversion is to handle the fact that time_t's size is
       platform-defined; so we cast it to 64 bits. tv_nsec is defined as long. */
       g_critical ("Clock returned a time that does not fit in a 64-bit integer "
-                  "in nanoseconds (seconds %" PRId64 ", nanoseconds "
+                  "in nanoseconds (seconds %" G_GINT64_FORMAT ", nanoseconds "
                   "%ld.)", (gint64) ts.tv_sec, ts.tv_nsec);
       return FALSE;
     }

--- a/eosmetrics/emtr-util.c
+++ b/eosmetrics/emtr-util.c
@@ -94,8 +94,8 @@ emtr_util_get_current_time (clockid_t clock_id,
       return FALSE;
     }
 
-  gint64 detected_time = (NANOSECONDS_PER_SECOND * ((gint64) ts.tv_sec))
-                          + ((gint64) ts.tv_nsec);
+  gint64 detected_time =
+    (NANOSECONDS_PER_SECOND * ((gint64) ts.tv_sec)) + ((gint64) ts.tv_nsec);
   if (detected_time < (G_MININT64 / 2) || detected_time > (G_MAXINT64 / 2))
     {
       g_critical ("Clock returned a time that may result in arithmetic that "


### PR DESCRIPTION
We don't need to include inttypes.h just to use PRId64 when GLib already
provides an equivalent macro. Also, we use the G_*_FORMAT macros in
other places in the metrics system, but this was the only remaining
use of PRId64.

[endlessm/eos-sdk#3254]