### PR TITLE
Fix memory leak of event sequences.

### DIFF
--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -1087,8 +1087,8 @@ emtr_event_recorder_record_progress (EmtrEventRecorder *self,
 
   key = get_normalized_form_of_variant (key);
 
-  GVariant *event_id_with_key = combine_event_id_with_key (parsed_event_id,
-                                                           key);
+  GVariant *event_id_with_key =
+    combine_event_id_with_key (parsed_event_id, key);
   GPtrArray *event_sequence =
     g_hash_table_lookup (priv->events_by_id_with_key, event_id_with_key);
   g_variant_unref (event_id_with_key);

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -992,17 +992,17 @@ emtr_event_recorder_record_start (EmtrEventRecorder *self,
           gchar *key_as_string = g_variant_print (key, TRUE);
           g_variant_unref (key);
 
-          g_warning ("Ignoring request to start event of type %s with key %s "
-                     "because there is already an unstopped start event with this "
+          g_warning ("Restarted event of type %s with key %s; there was "
+                     "already an unstopped start event with this "
                      "type and key.", event_id, key_as_string);
 
           g_free (key_as_string);
         }
       else
         {
-          g_warning ("Ignoring request to start event of type %s with NULL key "
-                     "because there is already an unstopped start event with "
-                     "this type and key.", event_id);
+          g_warning ("Restarted event of type %s with NULL key; there was "
+                     "already an unstopped start event with this type and key.",
+                     event_id);
         }
       goto finally;
     }

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -244,21 +244,6 @@ combine_event_id_with_key (uuid_t    event_id,
   return g_variant_new ("(aymv)", &event_id_builder, key);
 }
 
-/* Variants sent to D-Bus are not allowed to be NULL or maybe types. */
-static GVariant *
-get_time_with_maybe_variant (EmtrEventRecorder *self,
-                             gint64             relative_time,
-                             GVariant          *payload)
-{
-  EmtrEventRecorderPrivate *priv =
-    emtr_event_recorder_get_instance_private (self);
-
-  gboolean has_payload = (payload != NULL);
-  GVariant *maybe_payload = has_payload ?
-    payload : priv->empty_auxiliary_payload;
-  return g_variant_new ("(xbv)", relative_time, has_payload, maybe_payload);
-}
-
 static gboolean
 contains_maybe_variant (GVariant *variant)
 {
@@ -283,8 +268,16 @@ append_event_to_sequence (EmtrEventRecorder *self,
                           gint64             relative_time,
                           GVariant          *auxiliary_payload)
 {
+  EmtrEventRecorderPrivate *priv =
+    emtr_event_recorder_get_instance_private (self);
+
+  /* Variants sent to D-Bus are not allowed to be NULL or maybe types. */
+  gboolean has_payload = (auxiliary_payload != NULL);
+  GVariant *maybe_payload =
+    has_payload ? auxiliary_payload : priv->empty_auxiliary_payload;
   GVariant *event =
-    get_time_with_maybe_variant (self, relative_time, auxiliary_payload);
+    g_variant_new ("(xbv)", relative_time, has_payload, maybe_payload);
+
   g_array_append_val (event_sequence, event);
 }
 

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -252,7 +252,7 @@ contains_maybe_variant (GVariant *variant)
 
   // type_string belongs to the GVariant and should not be freed.
   const gchar *type_string = g_variant_get_type_string (variant);
-  gchar *found_character = strstr (type_string, "m");
+  gchar *found_character = strchr (type_string, 'm');
   if (found_character != NULL)
     {
       g_critical ("Maybe type found in auxiliary payload. These are not "

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -283,10 +283,9 @@ append_event_to_sequence (EmtrEventRecorder *self,
                           gint64             relative_time,
                           GVariant          *auxiliary_payload)
 {
-  GVariant *curr_event_variant = get_time_with_maybe_variant (self,
-                                                              relative_time,
-                                                              auxiliary_payload);
-  g_array_append_val (event_sequence, curr_event_variant);
+  GVariant *event =
+    get_time_with_maybe_variant (self, relative_time, auxiliary_payload);
+  g_array_append_val (event_sequence, event);
 }
 
 /*
@@ -409,8 +408,8 @@ send_event_sequence_to_dbus (EmtrEventRecorder *self,
   g_variant_builder_init (&event_sequence_builder, G_VARIANT_TYPE ("a(xbv)"));
   for (gint i = 0; i < event_sequence->len; i++)
     {
-      GVariant *current = g_array_index (event_sequence, GVariant *, i);
-      g_variant_builder_add_value (&event_sequence_builder, current);
+      GVariant *event = g_array_index (event_sequence, GVariant *, i);
+      g_variant_builder_add_value (&event_sequence_builder, event);
     }
   GVariant *event_sequence_variant =
     g_variant_builder_end (&event_sequence_builder);


### PR DESCRIPTION
When the event recorder API is finalized, start and progress events
without corresponding stops were leaked. Use GPtrArray with a destroy
function and proper ref counting to fix the leak.

[endlessm/eos-sdk#599]