### PR TITLE
Bump version number to 0.4 stable series

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ m4_define([_EMTR_API_VERSION_MACRO], [0])
 # Minor and micro versions: increment micro version when making a release. Minor
 # version is even for a stable release and odd for a development release.
 # When making any release, if the API changes, set the interface age to 0.
-m4_define([_EMTR_MINOR_VERSION_MACRO], [3])
+m4_define([_EMTR_MINOR_VERSION_MACRO], [4])
 m4_define([_EMTR_MICRO_VERSION_MACRO], [0])
 m4_define([_EMTR_INTERFACE_AGE_MACRO], [0])
 


### PR DESCRIPTION
We are releasing Endless OS 2.4 and this has new API, so we should make
a new stable series.

[endlessm/eos-sdk#3418]