### PR TITLE
Support non-srcdir builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,7 @@ EosMetrics_@EMTR_API_VERSION@_gir_SCANNERFLAGS = \
 	--identifier-prefix=Emtr \
 	--symbol-prefix=emtr \
 	-DCOMPILING_EOS_METRICS \
+	-I$(top_builddir)/eosmetrics \
 	$(NULL)
 EosMetrics_@EMTR_API_VERSION@_gir_LIBS = libeosmetrics-@EMTR_API_VERSION@.la
 EosMetrics_@EMTR_API_VERSION@_gir_FILES = $(introspection_sources)

--- a/eosmetrics/Makefile.am.inc
+++ b/eosmetrics/Makefile.am.inc
@@ -48,6 +48,7 @@ libeosmetrics_@EMTR_API_VERSION@_la_SOURCES = \
 libeosmetrics_@EMTR_API_VERSION@_la_CPPFLAGS = \
 	@EOSMETRICS_CFLAGS@ \
 	@EOS_C_COVERAGE_CFLAGS@ \
+	-I$(top_builddir)/eosmetrics \
 	-DG_LOG_DOMAIN=\"EosMetrics\" \
 	-DCOMPILING_EOS_METRICS \
 	-D_POSIX_C_SOURCE=200112L \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -25,6 +25,7 @@ LIBRARY_TEST_FLAGS = \
 	@EOSMETRICS_CFLAGS@ \
 	@EOS_C_COVERAGE_CFLAGS@ \
 	-I$(top_srcdir) \
+	-I$(top_builddir)/eosmetrics \
 	-DCOMPILING_EOS_METRICS \
 	-D_POSIX_C_SOURCE=200112L \
 	$(NULL)
@@ -41,6 +42,7 @@ EOSMETRICS_TEST_FLAGS = \
 	@EOSMETRICS_CFLAGS@ \
 	@EOS_C_COVERAGE_CFLAGS@ \
 	-I$(top_srcdir) \
+	-I$(top_builddir)/eosmetrics \
 	$(NULL)
 EOSMETRICS_TEST_LIBS = @EOSMETRICS_LIBS@
 


### PR DESCRIPTION
emtr-version.h is generated, so we need to add some -I options to various
compiler invocations in order to be able to find it in the builddir.

https://phabricator.endlessm.com/T12541