### PR TITLE
Add TravisCI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+dist: trusty
+
+services: docker
+
+before_install:
+    - docker pull ebassi/endlessci:sdk
+
+before_script:
+    - echo 'FROM ebassi/endlessci:sdk' > Dockerfile
+    - echo 'ADD . /home/jhbuildci/source/eos-metrics' >> Dockerfile
+    - echo 'RUN chown -hR jhbuildci /home/jhbuildci/source/eos-metrics/* /home/jhbuildci/source/eos-metrics/.*' >> Dockerfile
+    - echo 'USER jhbuildci' >> Dockerfile
+    - docker build -t withgit .
+
+script:
+    - docker run -t withgit /bin/sh -c '/usr/bin/endless-build-module --check eos-metrics'


### PR DESCRIPTION
We want to use Travis to perform CI on this module. For this reason, we
use Docker, using a Docker image we prepared in advance, to deal with
the dependencies needed to build eos-metrics and that do not exist on
the Ubuntu 14.04 base OS that Travis provides us.

