### PR TITLE
dbus: Add Environment property

### DIFF
--- a/data/com.endlessm.Metrics.xml
+++ b/data/com.endlessm.Metrics.xml
@@ -41,6 +41,9 @@ License along with eos-metrics.  If not, see
     opted out. -->
     <property name="Enabled" type="b" access="read"/>
 
+    <!-- Environment: The metrics environment, test, dev or production. -->
+    <property name="Environment" type="s" access="read"/>
+
     <!--
       SetEnabled:
       @enabled: whether the metrics server is enabled


### PR DESCRIPTION
Provides the environment as a DBUS property, to be able to differentiate
between development and production images inside flatpak apps.

https://phabricator.endlessm.com/T26548