### PR TITLE
Add TrackingId property to server

### DIFF
--- a/data/com.endlessm.Metrics.xml
+++ b/data/com.endlessm.Metrics.xml
@@ -41,6 +41,10 @@ License along with eos-metrics.  If not, see
     opted out. -->
     <property name="Enabled" type="b" access="read"/>
 
+    <!-- TrackingId: The identifier associated with metrics uploaded by this system.
+    -->
+    <property name="TrackingId" type="s" access="read"/>
+
     <!--
       SetEnabled:
       @enabled: whether the metrics server is enabled


### PR DESCRIPTION
This will allow the metrics page in control center to display the
current tracking ID to the user.

This does not increase information leakage to applications: all
applications (even those in a sandbox) can already read the machine ID,
which is "more valuable" than the user-resettable metrics ID.

This does not actually *implement* this property; it merely adds the API that client and service can hook up to.

https://phabricator.endlessm.com/T28869