### PR TITLE
Use session bus config for mock system bus

### DIFF
--- a/tests/test-daemon-integration.py
+++ b/tests/test-daemon-integration.py
@@ -48,7 +48,13 @@ class TestDaemonIntegration(dbusmock.DBusTestCase):
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
         """Set up a mock system bus."""
-        klass.start_system_bus()
+        # The dbusmock library generates its own D-Bus configuration when
+        # using DBusTestCase.start_system_bus, which breaks in environments
+        # where D-Bus needs special configuration, such as our buildstream
+        # test environment. Instead, we will use start_session_bus and treat
+        # it like a system bus in a similar way to dbusmock.
+        klass.start_session_bus()
+        os.environ['DBUS_SYSTEM_BUS_ADDRESS'] = os.environ['DBUS_SESSION_BUS_ADDRESS']
         klass.dbus_con = klass.get_dbus(system_bus=True)
 
     def setUp(self):


### PR DESCRIPTION
The python-dbusmock library generates its own dbus configuration when
using `DBusTestCase.start_system_bus`, which breaks in [certain
environments](https://github.com/endlessm/endless-sdk-flatpak/pull/84) where dbus needs special configuration. This change uses
`start_session_bus`, instead, with an additional step to set the
`DBUS_SYSTEM_BUS_ADDRESS` environment variable.

https://phabricator.endlessm.com/T30304