### PR TITLE
Correctly pass null payload to StartAggregateTimer

### DIFF
--- a/eosmetrics/emtr-aggregate-timer-private.h
+++ b/eosmetrics/emtr-aggregate-timer-private.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 EmtrAggregateTimer *emtr_aggregate_timer_new (EmerEventRecorderServer *dbus_proxy,
                                               GVariant                *event_id,
                                               GVariant                *aggregate_key,
+                                              gboolean                 has_payload,
                                               GVariant                *auxiliary_payload);
 
 G_END_DECLS

--- a/eosmetrics/emtr-aggregate-timer.c
+++ b/eosmetrics/emtr-aggregate-timer.c
@@ -127,16 +127,23 @@ EmtrAggregateTimer *
 emtr_aggregate_timer_new (EmerEventRecorderServer *dbus_proxy,
                           GVariant                *event_id,
                           GVariant                *aggregate_key,
+                          gboolean                 has_payload,
                           GVariant                *auxiliary_payload)
 {
   EmtrAggregateTimer *self;
+
+  g_return_val_if_fail (aggregate_key != NULL, NULL);
+  g_return_val_if_fail (g_variant_is_of_type (aggregate_key, G_VARIANT_TYPE_VARIANT), NULL);
+
+  g_return_val_if_fail (auxiliary_payload != NULL, NULL);
+  g_return_val_if_fail (g_variant_is_of_type (auxiliary_payload, G_VARIANT_TYPE_VARIANT), NULL);
 
   self = g_object_new (EMTR_TYPE_AGGREGATE_TIMER, NULL);
 
   emer_event_recorder_server_call_start_aggregate_timer (dbus_proxy,
                                                          event_id,
                                                          aggregate_key,
-                                                         TRUE,
+                                                         has_payload,
                                                          auxiliary_payload,
                                                          NULL,
                                                          on_server_aggregate_timer_started_cb,

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -70,10 +70,11 @@
  * // Records a single instance of MEANINGLESS_EVENT along with the current
  * // time.
  * eventRecorder.record_event(MEANINGLESS_EVENT, null);
- * // Records the fact that MEANINGLESS_AGGREGATED_EVENT occurred 23
- * // times since the last time it was recorded.
- * eventRecorder.record_events(MEANINGLESS_AGGREGATED_EVENT,
- *   23, null);
+ * // Records the fact that MEANINGLESS_AGGREGATED_EVENT occurred for some
+ * // duration
+ * let timer = eventRecorder.start_aggregate_timer(
+ *   MEANINGLESS_AGGREGATED_EVENT, null, null);
+ * timer.stop()
  * // Records MEANINGLESS_EVENT_WITH_AUX_DATA along with some auxiliary data and
  * // the current time.
  * eventRecorder.record_event(MEANINGLESS_EVENT_WITH_AUX_DATA,

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -66,18 +66,14 @@
  * const MEANINGLESS_AGGREGATED_EVENT = "01ddd9ad-255a-413d-8c8c-9495d810a90f";
  * const MEANINGLESS_EVENT_WITH_AUX_DATA =
  *   "9f26029e-8085-42a7-903e-10fcd1815e03";
- *
  * let eventRecorder = EosMetrics.EventRecorder.get_default();
- *
  * // Records a single instance of MEANINGLESS_EVENT along with the current
  * // time.
  * eventRecorder.record_event(MEANINGLESS_EVENT, null);
- *
  * // Records the fact that MEANINGLESS_AGGREGATED_EVENT occurred 23
  * // times since the last time it was recorded.
  * eventRecorder.record_events(MEANINGLESS_AGGREGATED_EVENT,
  *   23, null);
- *
  * // Records MEANINGLESS_EVENT_WITH_AUX_DATA along with some auxiliary data and
  * // the current time.
  * eventRecorder.record_event(MEANINGLESS_EVENT_WITH_AUX_DATA,

--- a/eosmetrics/emtr-event-recorder.c
+++ b/eosmetrics/emtr-event-recorder.c
@@ -1319,13 +1319,16 @@ emtr_event_recorder_start_aggregate_timer (EmtrEventRecorder *self,
 
   get_uuid_builder (parsed_event_id, &event_id_builder);
 
-  maybe_payload =
-    auxiliary_payload ? auxiliary_payload : priv->empty_auxiliary_payload;
+  if (auxiliary_payload == NULL)
+    maybe_payload = priv->empty_auxiliary_payload;
+  else
+    maybe_payload = g_variant_new_variant (auxiliary_payload);
 
   return emtr_aggregate_timer_new (priv->dbus_proxy,
                                    g_variant_builder_end (&event_id_builder),
                                    g_variant_new_variant (aggregate_key),
-                                   g_variant_new_variant (maybe_payload));
+                                   auxiliary_payload != NULL,
+                                   maybe_payload);
 }
 
 #undef _IS_VARIANT

--- a/tests/test-daemon-integration.py
+++ b/tests/test-daemon-integration.py
@@ -619,6 +619,19 @@ class TestDaemonIntegration(dbusmock.DBusTestCase):
         timer.stop()
         self.await_method_call("StopTimer")
 
+    def test_start_timer_passes_null_payload(self):
+        key_string = "org.gnome.Builder.desktop"
+        key_variant = GLib.Variant.new_string(key_string)
+        timer, calls = self.call_start_timer(key_variant, None)
+        self.assertIsInstance(timer, EosMetrics.AggregateTimer)
+        self.assertEqual(calls[0][2][1], key_string)
+        self.assertEqual(calls[0][2][2], False)
+        self.assertEqual(calls[0][2][3], dbus.Boolean(False, variant_level=1))
+
+        # Now stop it
+        timer.stop()
+        self.await_method_call("StopTimer")
+
     def test_timer_calls_stop_when_disposed(self):
         key_variant = GLib.Variant.new_uint32(42)
         payload_variant = None


### PR DESCRIPTION
Payloads are nullable, but D-Bus (unlike GVariant) does not have a 'maybe'
type. Throughout this API, it is faked by passing a pair of parameters:

- a boolean, indicating whether the payload is conceptually non-null
- a variant, which contains the real payload if the boolean is true, or
  a dummy value `<false>` if not

(Side-note: a better representation IMHO would be to use a list, with a
zero-element list meaning "nothing" and a one-element list meaning "just
x". But it's 8 years too late for that.)

Previously, emtr_event_recorder_start_aggregate_timer() handled a null
payload incorrectly. It would unconditionally pass true for the
has_payload parameter, and would box the dummy value inside a second
layer of variant, `<<false>>`. Handle this case correctly.

https://phabricator.endlessm.com/T33232
