### PR TITLE
Allow starting aggregate timer with particular UID

### DIFF
--- a/data/com.endlessm.Metrics.xml
+++ b/data/com.endlessm.Metrics.xml
@@ -154,6 +154,7 @@ License along with eos-metrics.  If not, see
 
     <!--
       StartAggregateTimer:
+      @user_id: user ID
       @event_id: event type UUID, as an array of 16 bytes
       @aggregate_key: a key to aggregate events
       @has_payload: whether the start event has a payload
@@ -164,16 +165,12 @@ License along with eos-metrics.  If not, see
 
       @payload is ignored if @has_payload is FALSE. (This is to compensate for
       DBus's lack of maybe types.)
-
-      @aggregate_key is the domain-specific key to aggregate. It can be, for
-      example, the application id when tracking applications, or the unix user
-      id when tracking session times.
     -->
     <method name="StartAggregateTimer">
+      <arg type="u" name="user_id"/>
       <arg type="ay" name="event_id">
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>
-      <arg type="v" name="aggregate_key"/>
       <arg type="b" name="has_payload"/>
       <arg type="v" name="payload"/>
       <arg type="o" name="timer_object_path" direction="out"/>

--- a/docs/reference/eosmetrics/eosmetrics-sections.txt
+++ b/docs/reference/eosmetrics/eosmetrics-sections.txt
@@ -24,6 +24,7 @@ emtr_event_recorder_record_progress
 emtr_event_recorder_record_stop
 emtr_event_recorder_record_stop_sync
 emtr_event_recorder_start_aggregate_timer
+emtr_event_recorder_start_aggregate_timer_with_uid
 <SUBSECTION Standard>
 EMTR_EVENT_RECORDER
 EMTR_EVENT_RECORDER_CLASS

--- a/eosmetrics/emtr-aggregate-timer-private.h
+++ b/eosmetrics/emtr-aggregate-timer-private.h
@@ -27,8 +27,8 @@
 G_BEGIN_DECLS
 
 EmtrAggregateTimer *emtr_aggregate_timer_new (EmerEventRecorderServer *dbus_proxy,
+                                              uid_t                    uid,
                                               GVariant                *event_id,
-                                              GVariant                *aggregate_key,
                                               gboolean                 has_payload,
                                               GVariant                *auxiliary_payload);
 

--- a/eosmetrics/emtr-aggregate-timer.c
+++ b/eosmetrics/emtr-aggregate-timer.c
@@ -125,15 +125,12 @@ on_server_aggregate_timer_started_cb (GObject      *source_object,
 
 EmtrAggregateTimer *
 emtr_aggregate_timer_new (EmerEventRecorderServer *dbus_proxy,
+                          uid_t                    uid,
                           GVariant                *event_id,
-                          GVariant                *aggregate_key,
                           gboolean                 has_payload,
                           GVariant                *auxiliary_payload)
 {
   EmtrAggregateTimer *self;
-
-  g_return_val_if_fail (aggregate_key != NULL, NULL);
-  g_return_val_if_fail (g_variant_is_of_type (aggregate_key, G_VARIANT_TYPE_VARIANT), NULL);
 
   g_return_val_if_fail (auxiliary_payload != NULL, NULL);
   g_return_val_if_fail (g_variant_is_of_type (auxiliary_payload, G_VARIANT_TYPE_VARIANT), NULL);
@@ -141,8 +138,8 @@ emtr_aggregate_timer_new (EmerEventRecorderServer *dbus_proxy,
   self = g_object_new (EMTR_TYPE_AGGREGATE_TIMER, NULL);
 
   emer_event_recorder_server_call_start_aggregate_timer (dbus_proxy,
+                                                         uid,
                                                          event_id,
-                                                         aggregate_key,
                                                          has_payload,
                                                          auxiliary_payload,
                                                          NULL,

--- a/eosmetrics/emtr-event-recorder.h
+++ b/eosmetrics/emtr-event-recorder.h
@@ -138,8 +138,12 @@ void               emtr_event_recorder_record_stop_sync   (EmtrEventRecorder *se
 EMTR_AVAILABLE_IN_0_5
 EmtrAggregateTimer *emtr_event_recorder_start_aggregate_timer (EmtrEventRecorder *self,
                                                                const gchar       *event_id,
-                                                               GVariant          *aggregate_key,
                                                                GVariant          *auxiliary_payload);
+EMTR_AVAILABLE_IN_0_5
+EmtrAggregateTimer *emtr_event_recorder_start_aggregate_timer_with_uid (EmtrEventRecorder *self,
+                                                                        uid_t              uid,
+                                                                        const gchar       *event_id,
+                                                                        GVariant          *auxiliary_payload);
 G_END_DECLS
 
 #endif /* EMTR_EVENT_RECORDER_H */

--- a/tests/test-event-recorder.c
+++ b/tests/test-event-recorder.c
@@ -427,7 +427,6 @@ test_event_recorder_aggregate_start_stop_sync (struct RecorderFixture *fixture,
 
   timer = emtr_event_recorder_start_aggregate_timer (fixture->recorder,
                                                      MEANINGLESS_EVENT,
-                                                     g_variant_new_uint32 (1001),
                                                      NULL);
   emtr_aggregate_timer_stop (timer);
 }
@@ -440,7 +439,6 @@ test_event_recorder_aggregate_start_stop_sync_with_payload (struct RecorderFixtu
 
   timer = emtr_event_recorder_start_aggregate_timer (fixture->recorder,
                                                      MEANINGLESS_EVENT,
-                                                     g_variant_new_string ("org.gnome.Builder.desktop"),
                                                      g_variant_new_string ("org.gnome.Builder.desktop"));
   // Destroying the timer should call stop here
 }


### PR DESCRIPTION
StartAggregateTimer() accepts a non-nullable aggregate key and a
nullable payload. The daemon internally aggregates events based on a
four-tuple of:

- date (implicit)
- UID of the calling process (currently implicit, determined by asking
  the D-Bus daemon for the UID of the caller)
- aggregate key
- payload

We currently have two users of this API:

1. Counting time an app is open for a given user. In this case the
   aggregate key and payload are identical.
2. Counting time spent logged in by each user on the system. In this
   case the aggregate key is the UID of the logged-in user, and the
   payload is null (while UIDs are not exactly unique, they are useless
   to us on the server). This event is recorded by a system-wide daemon
   running as root, so the UID in the tuple above is 0.

In the first case, the aggregate key is completely redundant. In the
second case, if we could arrange for the daemon to use the logged-in
user's UID in its internal key, rather than root (0), then we would not
need the aggregate key either. So it seems we can probably get rid of
the aggregate key and simplify the API.

One solution would be to record the session time event from within the
user session, so that the calling process's UID would be the UID we
want. I briefly looked at this and decided against it, on the basis that
it would be sad to have an extra process running in the user
session just to call a D-Bus method at the start and then hang around
until the session ends.

The alternative solution implemented here is to make the Unix UID
caller-supplied in the D-Bus API. This was the approach taken in the
older methods on this interface. Unlike those older methods, we then
optionally expose this parameter in the C API.

Having made this change, the aggregate_key is redundant and is not
present in the new API.

https://phabricator.endlessm.com/T33252
